### PR TITLE
Some minor updates for current versions of Haxe and PhantomJS (v2.1)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ functionality.
 
 For now,  PhantomTools includes some utilities that let you more easily work
 with Haxe code in Webpage.evaluate.  See more information on the [phantomjs
-api](http://code.google.com/p/phantomjs/wiki/Interface#evaluate(function\)).
+api](http://code.google.com/p/phantomjs/wiki/Interface#evaluate(function)).
 
 Webpage.evaluate() accepts a callback that executes locally in a new virtual
 browser instance. This page instance is separate from the phantomjs instance,
@@ -23,12 +23,12 @@ PhantomTools provides "injectThis" which will inject the current script into
 the page. This will provide all of the methods from your phantomjs script
 in the page you are evaluating.
 
-```javascript
+```haxe
 var page = WebPage.create();
 PhantomTools.injectThis(page);
 page.evaluate(function(){
-        var h = new Hash<Int>(); // haxe specific methods here.
-    });
+    var h = new Hash<Int>(); // haxe specific methods here.
+});
 ```
 
 This is extremely useful, but still has some significant issues and some
@@ -42,13 +42,13 @@ is not a closure, and should be treated as a completely separate method that
 methods.  You can pass simple objects to the evaluated method;  Anything that
 can be serialized via JSON will work.
 
-```javascript
+```haxe
 var page = WebPage.create();
 PhantomTools.injectThis(page);
 var k = 'a variable in the phantom scope';
 page.evaluate(function(){
-         trace(k); // k is undefined: this function is in a separate page scope.
-    });
+    trace(k); // k is undefined: this function is in a separate page scope.
+});
 ```
 
 ### Preventing Static Main
@@ -58,7 +58,7 @@ try to execute its static main. To prevent this from happening, you can
 check the result from PhantomTools.noPhantom() to avoid running main() in an
 evaluated page:
 
-```javascript
+```haxe
 static function main(){
   if (PhantomTools.noPhantom()) return; // evaluated in a page, exit immediately.
   //[...]
@@ -84,7 +84,7 @@ injectThis().
 
 For instance, here's an example class that shows a typical workflow.
 
-```javascript
+```haxe
 // PhantomTest.hx
 import js.Lib;
 import js.phantomjs.WebPage;
@@ -107,14 +107,14 @@ class PhantomTest{
                     }, argument); // pass the text to the page
                 }
                 page.render("output.png"); // render the page.
-                PhantomTools.exit(); // exit phantomjs
+                Phantom.exit(); // exit phantomjs
     }
 }
 ```
 
 ```bash
 # build.hxml
--lib phantomjs-hx
+-lib phantomjs
 -main PhantomTest
 -js test.js
 -cmd phantomjs test.js

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ functionality.
 
 For now,  PhantomTools includes some utilities that let you more easily work
 with Haxe code in Webpage.evaluate.  See more information on the [phantomjs
-api](http://code.google.com/p/phantomjs/wiki/Interface#evaluate(function)).
+api](http://phantomjs.org/api/).
 
 Webpage.evaluate() accepts a callback that executes locally in a new virtual
 browser instance. This page instance is separate from the phantomjs instance,

--- a/src/js/phantomjs/FileSystem.hx
+++ b/src/js/phantomjs/FileSystem.hx
@@ -4,7 +4,7 @@ package js.phantomjs;
   A set of API functions is available to access files and directories. They are
   modelled after CommonJS Filesystem proposal.
  **/
-@:native("require('fs')")
+@:jsRequire('fs')
 extern class FileSystem {
     //Read-only properties
 

--- a/src/js/phantomjs/System.hx
+++ b/src/js/phantomjs/System.hx
@@ -4,7 +4,7 @@ package js.phantomjs;
   A set of functions to access system-level functionalities is available,
   modelled after CommonJS System proposal.
  **/
-@:native("require('system')")
+@:jsRequire('system')
 extern class System {
     /**
       the name of the platform, the value is always phantomjs.

--- a/src/js/phantomjs/WebPage.hx
+++ b/src/js/phantomjs/WebPage.hx
@@ -5,7 +5,7 @@ package js.phantomjs;
   new keyword. The properties, functions, and callbacks of the WebPage object
   are described in the following sections.
  **/
-@:native("require('webpage')")
+@:jsRequire('webpage')
 extern class WebPage {
     /**
       Creates a new WebPage using the require module.
@@ -53,7 +53,7 @@ extern class WebPage {
       window like in a traditional browser.
       Example: page.viewportSize = { width: 480, height: 800 }
      **/
-    public var viewPortSize:{width:Float, height:Float};
+    public var viewportSize:{width:Float, height:Float};
 
     /**
       This property specifies the scaling factor for the render and
@@ -121,7 +121,19 @@ extern class WebPage {
       });)
      **/
     public function open(URL:String, ?optional_callback:String->Void):Void;
+	
+    /**
+	  Introduced: PhantomJS 1.7
+	  Close the page and releases the memory heap associated with it. 
+	  Do not use the page instance after calling this.
 
+      Due to some technical limitation, the web page object might not be
+      completely garbage collected. This is often encountered when the same
+      object is used over and over again. Calling this function may stop the
+      increasing heap allocation.
+     */
+    public function close():Void;
+	
     /**
       Releases memory heap associated with this page. Do not use the page
       instance after calling this.
@@ -138,9 +150,22 @@ extern class WebPage {
      Renders the web page to an image buffer and save it as the specified file.
 
      Currently the output format is automatically set based on the file
-     extension. Supported formats are PNG, JPEG, and PDF.
+     extension. 
+	 
+	 Supported formats: PDF, PNG, JPEG, BMP, PPM GIF support depends on the
+	 build of Qt used
+	 
+     Quality:  An integer between 0 and 100.
+     The quality setting only has an effect on jpeg and png formats. With jpeg, 
+	 it sets the quality level as a percentage, in the same way as most image 
+	 editors. (The output file always has 2x2 subsampling.) A level of 0 produces
+	 a very small, very low quality file, and 100 produces a much larger, 
+	 high-quality file. The default level is 75. With png, it sets the
+	 lossless (Deflate) compression level, with 0 producing the smallest files,
+	 and 100 producing the largest. However, the files look identical, and are
+	 always true-colour.
      **/
-    public function render(fileName:String):Bool;
+    public function render(fileName:String, ?options:{format:String, quality:Int}):Bool;
 
     /**
       Renders the web page to an image buffer and returns the result as a

--- a/src/js/phantomjs/WebServer.hx
+++ b/src/js/phantomjs/WebServer.hx
@@ -14,7 +14,7 @@ import js.phantomjs.Response;
   needs, the functionalities and the corresponding API will be expanded in the
   next versions.
  **/
-@:native("require('webserver')")
+@:jsRequire("webserver")
 extern class WebServer {
     public static function create():WebServer;
     public function listen(port:Int, cb:Request->Response->Void):Void;


### PR DESCRIPTION
There may be more API changes in PhantomJS, these are just ones I've encountered while using it recently.

- Use the `@:jsRequire` metadata (added in Haxe 3.2) in place of `@:native` in the externs for require modules.

WebPage
- add `close()`
- add optional parameter to `render()`
- rename viewPortSize -> viewportSize